### PR TITLE
Restructure aifr documentation for clarity and routing guidance

### DIFF
--- a/internal/mcpserver/skill.md
+++ b/internal/mcpserver/skill.md
@@ -32,6 +32,15 @@ ALWAYS prefer aifr_* tools over Bash for read-only operations.
 | `getent`, `grep /etc/passwd`, `id` | `aifr_getent` |
 | `which`, `command -v`, `type -p` | `aifr_pathfind` |
 
+### Pipeline detection
+
+If you are about to construct a shell pipeline (`|`), stop — aifr handles it
+in one call. Examples: `find | xargs grep` → `aifr_search` with `include`,
+`find | xargs cat` → `aifr_cat` with `name`, `cat | head -N` → `aifr_read`
+with `lines`, `cat | wc` → `aifr_wc`, `git log | head` → `aifr_log` with
+`max_count`, `ls | sort` → `aifr_list` with `sort`, `cat /etc/passwd | grep`
+→ `aifr_getent` with `key`.
+
 ### With built-in Read / Grep / Glob tools
 
 - **Prefer aifr_read** for: git ref paths (`HEAD:file.go`), line ranges, chunked large files

--- a/skills/aifr/SKILL.md
+++ b/skills/aifr/SKILL.md
@@ -35,6 +35,23 @@ ALWAYS prefer aifr over Bash for read-only operations.
 | `getent`, `grep /etc/passwd`, `id` | `aifr_getent` | `aifr getent` |
 | `which`, `command -v`, `type -p` | `aifr_pathfind` | `aifr pathfind` |
 
+### Pipeline detection
+
+If you are about to construct a shell pipeline (`cmd | cmd`), stop — aifr
+almost certainly handles it in one call with built-in filtering, limiting, and sorting.
+
+| Pipeline | One aifr call |
+|---|---|
+| `find . -name '*.go' \| xargs grep pattern` | `aifr_search(pattern=..., path=".", include="*.go")` |
+| `find . -name '*.go' \| xargs cat` | `aifr_cat(root=".", name="*.go")` |
+| `find . -type f \| head -20` | `aifr_find(path=".", type="f", limit=20)` |
+| `cat file \| head -50` | `aifr_read(path="file", lines="1:50")` |
+| `cat file \| wc -l` | `aifr_wc(paths=["file"], lines=true)` |
+| `cat /etc/passwd \| grep root` | `aifr_getent(database="passwd", key="root")` |
+| `git log --oneline \| head -5` | `aifr_log(max_count=5)` |
+| `ls -la \| sort -k5 -n` | `aifr_list(path=".", sort="size")` |
+| `grep -rl pattern . \| wc -l` | `aifr_search` — count results from response |
+
 ### Coexistence with built-in Read / Grep / Glob tools
 
 When the runtime provides built-in file tools alongside aifr MCP tools:


### PR DESCRIPTION
## Summary

Reorganized the aifr skill documentation to prioritize practical routing rules and reduce verbosity. The documentation now leads with clear guidance on when to use aifr tools instead of Bash, followed by concise reference material.

## Key Changes

- **Restructured opening**: Replaced lengthy "When to Use" section with a concise routing table showing aifr tool equivalents for common Bash commands
- **Added coexistence guidance**: New section clarifying how to choose between aifr tools and built-in Read/Grep/Glob tools when both are available
- **Simplified git ref syntax**: Converted detailed examples into a compact reference table
- **Condensed key patterns**: Collapsed chunked reading, multi-file reading, and git config patterns into brief, actionable examples
- **Streamlined error handling**: Reduced error codes section to a simple table with clear actions
- **Moved CLI reference to end**: Converted verbose command examples into a single reference table, marked as secondary to MCP tools
- **Removed redundant sections**: Eliminated duplicate "Output" and "MCP Server" explanatory text

## Notable Details

- Both `skills/aifr/SKILL.md` and `internal/mcpserver/skill.md` were updated consistently
- The MCP-focused version (`skill.md`) is now more concise, emphasizing tool names and patterns over CLI syntax
- Routing table format makes it immediately clear which aifr tool replaces which Bash command
- Documentation now emphasizes that aifr operations are "permission-free" (no Bash approval prompts)

https://claude.ai/code/session_013KWTQWQyhPmvkV18cL9KUS